### PR TITLE
[PR] Stop extra version checks

### DIFF
--- a/includes/wsuwp-multiple-networks-capabilities.php
+++ b/includes/wsuwp-multiple-networks-capabilities.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace WSUWP\Multiple_Networks\Capabilities;
+
+add_filter( 'map_meta_cap', 'WSUWP\Multiple_Networks\Capabilities\remove_update_capabilities', 10, 2 );
+
+/**
+ * Remove any option or display for plugin, theme, and core updates
+ * on networks other than the main network.
+ *
+ * @since 1.7.0
+ *
+ * @param array  $caps
+ * @param string $cap
+ *
+ * @return array
+ */
+function remove_update_capabilities( $caps, $cap ) {
+	if ( is_main_network() ) {
+		return $caps;
+	}
+
+	$caps_check = array(
+		'update_plugins',
+		'delete_plugins',
+		'install_plugins',
+		'upload_plugins',
+		'update_themes',
+		'delete_themes',
+		'install_themes',
+		'upload_themes',
+		'update_core',
+	);
+
+	if ( in_array( $cap, $caps_check, true ) ) {
+		$caps[] = 'do_not_allow';
+	}
+
+	return $caps;
+}

--- a/includes/wsuwp-multiple-networks-updates.php
+++ b/includes/wsuwp-multiple-networks-updates.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace WSUWP\Multiple_Networks\Updates;
+
+add_action( 'muplugins_loaded', 'WSUWP\Multiple_Networks\Updates\remove_update_checks' );
+add_filter( 'schedule_event', 'WSUWP\Multiple_Networks\Updates\remove_wp_version_check_schedule' );
+
+/**
+ * Remove all core, plugin, and theme update checks from networks other
+ * than the main network.
+ *
+ * @since 1.7.0
+ */
+function remove_update_checks() {
+	if ( is_main_network() ) {
+		return;
+	}
+
+	remove_action( 'admin_init', '_maybe_update_core' );
+	remove_action( 'admin_init', '_maybe_update_plugins' );
+	remove_action( 'admin_init', '_maybe_update_themes' );
+
+	remove_action( 'init', 'wp_scheduled_update_checks' );
+
+	remove_action( 'wp_version_check', 'wp_version_check' );
+
+	remove_action( 'load-plugins.php', 'wp_update_plugins' );
+	remove_action( 'load-update.php', 'wp_update_plugins' );
+	remove_action( 'load-update-core.php', 'wp_update_plugins' );
+	remove_action( 'wp_update_plugins', 'wp_update_plugins' );
+
+	remove_action( 'load-themes.php', 'wp_update_themes' );
+	remove_action( 'load-update.php', 'wp_update_themes' );
+	remove_action( 'load-update-core.php', 'wp_update_themes' );
+	remove_action( 'wp_update_themes', 'wp_update_themes' );
+
+	remove_action( 'wp_maybe_auto_update', 'wp_maybe_auto_update' );
+}
+
+/**
+ * Avoid the scheduling of core version checks on networks other than
+ * the main network.
+ *
+ * @since 1.7.0
+ *
+ * @param object $event Object containing scheduled event data.
+ *
+ * @return bool|object
+ */
+function remove_wp_version_check_schedule( $event ) {
+	if ( is_main_network() ) {
+		return $event;
+	}
+
+	return false;
+}

--- a/wsuwp-multiple-networks.php
+++ b/wsuwp-multiple-networks.php
@@ -16,6 +16,7 @@ if ( ! defined( 'WPINC' ) ) {
 // Common functions.
 require dirname( __FILE__ ) . '/wsu-core-functions.php';
 require dirname( __FILE__ ) . '/includes/wsuwp-multiple-networks-updates.php';
+require dirname( __FILE__ ) . '/includes/wsuwp-multiple-networks-capabilities.php';
 
 // The core plugin class.
 require dirname( __FILE__ ) . '/includes/class-wsuwp-multiple-networks.php';

--- a/wsuwp-multiple-networks.php
+++ b/wsuwp-multiple-networks.php
@@ -15,6 +15,7 @@ if ( ! defined( 'WPINC' ) ) {
 
 // Common functions.
 require dirname( __FILE__ ) . '/wsu-core-functions.php';
+require dirname( __FILE__ ) . '/includes/wsuwp-multiple-networks-updates.php';
 
 // The core plugin class.
 require dirname( __FILE__ ) . '/includes/class-wsuwp-multiple-networks.php';


### PR DESCRIPTION
* Prevent core from checking for plugin, theme, and core updates when not on the main network.
* Prevent users (even super admins) from seeing any plugin, theme, core update information when not on the main network.

This should clean up the admin a bit and reduce the amount of unnecessary processing in the background for 60 networks checking the same info again and again. :)