### PR TITLE
[PR] Use `clean_site_cache` action over `refresh_blog_details`

### DIFF
--- a/includes/class-wsuwp-network-admin.php
+++ b/includes/class-wsuwp-network-admin.php
@@ -98,7 +98,7 @@ class WSUWP_Network_Admin {
 
 		add_action( 'admin_init', array( $this, 'remove_upgrade_notices' ) );
 
-		add_action( 'refresh_blog_details', array( $this, 'clear_site_request_cache' ) );
+		add_action( 'clean_site_cache', array( $this, 'clear_site_request_cache' ) );
 		add_action( 'delete_blog', array( $this, 'clear_site_request_cache' ) );
 
 		add_filter( 'pre_update_site_option_user_count', array( $this, 'update_network_user_count' ) );


### PR DESCRIPTION
`clean_site_cache` was added as a replacement in WordPress 4.6 and
the `refresh_blog_details` action is deprecated in the upcoming
4.9 release.