### PR TITLE
[PR] Compare current network as integer when moving a site

### DIFF
--- a/includes/class-wsuwp-network-site-info.php
+++ b/includes/class-wsuwp-network-site-info.php
@@ -137,7 +137,7 @@ class WSUWP_Network_Site_Info {
 
 						// Parse the user's sites for others on this network to see if we can remove this network's capabilities.
 						foreach ( $user_sites as $user_site_id => $user_site ) {
-							if ( $user_site->site_id === $current_details->site_id && $user_site_id !== $id ) {
+							if ( $user_site->site_id === (int) $current_details->site_id && $user_site_id !== $id ) {
 								$remove_from_network = false;
 								continue;
 							}


### PR DESCRIPTION
Previously this was a string to int comparison and would never match as `true`. This caused the users of sites moved between networks to be removed from the original network even when that user had other sites on that original network.